### PR TITLE
Add a dependabot to check for GH action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version 2:
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily


### PR DESCRIPTION
[Dependabot documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file). Dependabot will check our GH actions monthly for updates and create a PR for any that are out of date. 