### PR TITLE
Update GHA

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set-up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: yarn install
@@ -24,7 +24,7 @@ jobs:
         run: |
           yarn build
       - name: deploy frontend to gh pages
-        uses: crazy-max/ghaction-github-pages@v3     # https://github.com/crazy-max/ghaction-github-pages
+        uses: crazy-max/ghaction-github-pages@v4     # https://github.com/crazy-max/ghaction-github-pages
         with:
           target_branch: gh-pages
           build_dir: website/build

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set-up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: yarn install
         run: |
           yarn install

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set-up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 18
       - name: yarn install
         run: |
           yarn install

--- a/.github/workflows/test-build-s3.yml
+++ b/.github/workflows/test-build-s3.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set-up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: AWS Creds
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/test-build-s3.yml
+++ b/.github/workflows/test-build-s3.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set-up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: AWS Creds
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test-build-s3.yml
+++ b/.github/workflows/test-build-s3.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set-up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 18
       - name: AWS Creds
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
All of the Github Actions have been updated to the newest version, and the Node version has been set to 20. The new dependabot created a PR for each of these GHA updates, but now that we know it works I'm updating everything with one PR. You can see the dependabot's PRs here:
* https://github.com/OSU-Sustainability-Office/osu-sustainability-office.github.io/pull/21
* https://github.com/OSU-Sustainability-Office/osu-sustainability-office.github.io/pull/22
* https://github.com/OSU-Sustainability-Office/osu-sustainability-office.github.io/pull/23
* https://github.com/OSU-Sustainability-Office/osu-sustainability-office.github.io/pull/24