### PR TITLE
Update gh actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Set-up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 18
       - name: yarn install

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set-up Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test-build-s3.yml
+++ b/.github/workflows/test-build-s3.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 18
       - name: AWS Creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test-build-s3.yml
+++ b/.github/workflows/test-build-s3.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Set-up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 18
       - name: AWS Creds

--- a/.github/workflows/test-build-s3.yml
+++ b/.github/workflows/test-build-s3.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set-up Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
# Summary
This PR updates GitHub Actions dependencies to their latest major versions.

# Changes
- aws-actions/configure-aws-credentials: v4 → v5
- actions/setup-node: v4 → v5
- actions/checkout: v4 → v5